### PR TITLE
Make bt_deserialize take a buffer instead of bytes

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 # Available at setup time due to pyproject.toml
 from pybind11.setup_helpers import Pybind11Extension, build_ext
 
-__version__ = "1.0.0"
+__version__ = "1.0.1"
 
 # Note:
 #   Sort input source files if you glob sources to ensure bit-for-bit


### PR DESCRIPTION
This makes it more generic than taking only bytes, allowing other things
(like memoryviews) to be passed to avoid needing to copy into a bytes.
bytes itself implements the buffer protocol, so will continue to work as
expected when passed here.